### PR TITLE
fix: seeds without filters or filterSets not part of statistics

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -1,8 +1,9 @@
 const { rethinkdb: dbConfig } = require('./config')
 
 /**
+ * RethinkDB driver
+ *
  * @type {ReQL}
- * @const
  */
 const r = require('rethinkdb-js')(dbConfig)
 const { logger: log, languageDetection } = require('./config')
@@ -51,7 +52,8 @@ const OPERATION_TIMEOUT = 43200 // seconds (12 hours)
 async function detectLanguages (detectAll) {
   const type = TYPE.LANGUAGE_DETECTION
 
-  const id = await setInProgress(type).then(() => logStart(type))
+  await setInProgress(type)
+  const logId = await logStart(type)
 
   const query = r.db(VEIDEMANN_DB).table(VEIDEMANN_TABLE_EXTRACTED_TEXT)
   const cursor = detectAll
@@ -60,11 +62,11 @@ async function detectLanguages (detectAll) {
 
   // deliberately not await promise
   detectAndUpdate(cursor)
-    .then((metrics) => logEnd(id, { metrics }))
-    .catch((err) => logEnd(id, { error: err.message }))
-    .finally(() => setNotInProgress(TYPE.LANGUAGE_DETECTION))
+    .then((metrics) => logEnd(logId, { metrics }))
+    .catch((err) => logEnd(logId, { error: err.message }))
+    .finally(() => setNotInProgress(type))
 
-  return id
+  return logId
 }
 
 /**
@@ -102,8 +104,8 @@ async function detectAndUpdate (cursor) {
     }
   }
 
-  // collect a number (languageDetection.concurrency) of rows from the cursor and concurrently
-  // call the mapper function on the collected rows until cursor is exhausted
+  // collect a given number of rows from the cursor and concurrently
+  // call the given mapper function on the collected rows until cursor is exhausted
   await map(cursor, fn, languageDetection.concurrency)
 
   return metrics
@@ -119,7 +121,8 @@ async function detectAndUpdate (cursor) {
 async function updateEntities (name, labels) {
   const type = TYPE.SYNC_ENTITIES
 
-  const id = await setInProgress(type).then(() => logStart(type))
+  await setInProgress(type)
+  const logId = await logStart(type)
 
   let query = r.db(VEIDEMANN_DB).table(VEIDEMANN_TABLE_CRAWL_ENTITIES)
   if (labels) {
@@ -130,11 +133,11 @@ async function updateEntities (name, labels) {
   }
   // deliberately not await promise
   query.forEach((entity) => r.db(MAALFRID_DB).table(MAALFRID_TABLE_ENTITIES).insert(entity, { conflict: 'replace' })).run()
-    .then(result => logEnd(id, { result }))
-    .catch(error => logEnd(id, { error: error.message }))
+    .then(result => logEnd(logId, { result }))
+    .catch(error => logEnd(logId, { error: error.message }))
     .finally(() => setNotInProgress(type))
 
-  return id
+  return logId
 }
 
 /**
@@ -165,15 +168,16 @@ function filterMetaByName (selection, name) {
 async function updateSeeds () {
   const type = TYPE.SYNC_SEEDS
 
-  const id = await setInProgress(type).then(() => logStart(type))
+  await setInProgress(type)
+  const logId = await logStart(type)
 
   // deliberately not await promise
   r.db(MAALFRID_DB).table(MAALFRID_TABLE_SEEDS).insert(getSeedsOfEntities(), { conflict: 'replace' }).run()
-    .then(result => logEnd(id, { result }))
-    .catch(error => logEnd(id, { error: error.message }))
+    .then(result => logEnd(logId, { result }))
+    .catch(error => logEnd(logId, { error: error.message }))
     .finally(() => setNotInProgress(type))
 
-  return id
+  return logId
 }
 
 /**
@@ -197,26 +201,24 @@ function getSeedsOfEntities () {
 async function generateAggregate (startTime, endTime) {
   const type = TYPE.AGGREGATION
 
+  await setInProgress(type)
+
   const lowerBound = startTime || await findAggregateLowerBound()
   const upperBound = endTime || await findAggregateUpperBound(lowerBound)
 
-  if (lowerBound >= upperBound) {
-    throw FailedPreconditionError(`lowerBound (${lowerBound}) is greater than or equal to upperBound (${upperBound}`)
-  }
+  checkBounds(lowerBound, upperBound)
 
-  const id = await setInProgress(type)
-    .then(() => logStart(type, Object.assign(
-      {},
-      lowerBound ? { lowerBound } : {},
-      upperBound ? { upperBound } : {})))
+  const logId = await logStart(type, Object.assign(
+    {},
+    lowerBound ? { lowerBound } : {},
+    upperBound ? { upperBound } : {}))
 
   // deliberately not await promise
   r.db(MAALFRID_DB).table(MAALFRID_TABLE_AGGREGATE).insert(aggregateTexts(lowerBound, upperBound))
-    .then(result => logEnd(id, { result }))
-    .catch((error) => logEnd(id, { error: error.message }))
-    .then(() => setNotInProgress(type))
-
-  return id
+    .then(result => logEnd(logId, { result }))
+    .catch((error) => logEnd(logId, { error: error.message }))
+    .finally(() => setNotInProgress(type))
+  return logId
 }
 
 /**
@@ -238,11 +240,11 @@ async function findAggregateLowerBound () {
 }
 
 /**
- * Find the time of the earliest started jobExecution still running
+ * Find upperBound date
  *
  * @param {Date} lowerBound
  *
- * @returns {Promise<Date>}
+ * @returns {Promise<Date>} the start time of the earliest started jobExecution still running
  */
 async function findAggregateUpperBound (lowerBound) {
   const jobExecutionStates = await r.db(VEIDEMANN_DB).table(VEIDEMANN_TABLE_JOB_EXECUTIONS)
@@ -258,7 +260,7 @@ async function findAggregateUpperBound (lowerBound) {
  *
  * @param {Date} lowerBound Lower bound of execution start time
  * @param {Date} upperBound Upper bound of execution end time
- * @returns {Selection}
+ * @returns {Selection | *}
  */
 function aggregateTexts (lowerBound, upperBound) {
   return r.db(MAALFRID_DB).table(MAALFRID_TABLE_SEEDS).pluck('id')
@@ -269,7 +271,7 @@ function aggregateTexts (lowerBound, upperBound) {
     // only executions in state FINISHED/ABORTED_TIMEOUT/ABORTED_MANUAL
     .filter(r.row('state').eq('FINISHED').or(r.row('state').eq('ABORTED_TIMEOUT')).or(r.row('state').eq('ABORTED_MANUAL')))
     // only executions not already aggregated
-    .filter(r.row('startTime').during(lowerBound, upperBound))
+    .filter(getTimePredicate(lowerBound, upperBound) || true)
     // join with job executions
     .eqJoin('jobExecutionId', r.db(VEIDEMANN_DB).table(VEIDEMANN_TABLE_JOB_EXECUTIONS))
     // only job executions in state FINISHED or ABORTED_MANUAL
@@ -314,27 +316,38 @@ function aggregateTexts (lowerBound, upperBound) {
 async function generateStatistics (startTime, endTime, seedId) {
   const type = TYPE.STATISTICS
 
+  await setInProgress(type)
+
   const lowerBound = startTime || await findFilterLowerBound()
   const upperBound = endTime || await findFilterUpperBound()
 
-  if (lowerBound >= upperBound) {
-    throw FailedPreconditionError(`lowerbound (${lowerBound}) is greater than or equal to upperbound (${upperBound}`)
-  }
+  checkBounds(lowerBound, upperBound)
 
-  const id = await setInProgress(type)
-    .then(() => logStart(type, Object.assign(
-      {},
-      lowerBound ? { lowerBound } : {},
-      upperBound ? { upperBound } : {},
-      seedId ? { seedId } : {})))
+  const logId = await logStart(type, Object.assign(
+    {},
+    lowerBound ? { lowerBound } : {},
+    upperBound ? { upperBound } : {},
+    seedId ? { seedId } : {}))
 
-  // deliberately not await promise as this is a long running task
-  deleteStatistics(lowerBound, upperBound, seedId).then(() => processAggregate(lowerBound, upperBound, seedId))
-    .then(() => logEnd(id))
-    .catch(error => logEnd(id, { error: error.message }))
+  // deliberately not await promise
+  deleteStatistics(lowerBound, upperBound, seedId)
+    .then(() => processAggregate(lowerBound, upperBound, seedId))
+    .then(() => logEnd(logId))
+    .catch(error => logEnd(logId, { error: error.message }))
     .finally(() => setNotInProgress(type))
 
-  return id
+  return logId
+}
+
+/**
+ *
+ * @param {Date} lowerBound
+ * @param {Date} upperBound
+ */
+function checkBounds (lowerBound, upperBound) {
+  if (lowerBound >= upperBound && !(lowerBound === null && upperBound === null)) {
+    throw FailedPreconditionError(`lowerbound (${lowerBound}) is greater than or equal to upperbound (${upperBound}`)
+  }
 }
 
 /**
@@ -352,7 +365,7 @@ async function findFilterLowerBound () {
     .orderBy(r.desc('endTime'))
     .limit(1).run()
 
-  if (lastRun.length) {
+  if (lastRun.length > 0) {
     return lastRun[0].upperBound
   } else {
     return null
@@ -361,7 +374,7 @@ async function findFilterLowerBound () {
 
 /**
  *
- * @returns {Promise<Date>}
+ * @returns {Promise<Date>} the previous aggregation's upperBound
  */
 async function findFilterUpperBound () {
   /**
@@ -375,13 +388,13 @@ async function findFilterUpperBound () {
   if (aggregations.length) {
     return aggregations[0].upperBound
   } else {
-    throw FailedPreconditionError('could not find log entry of previous completed aggregations')
+    return null
   }
 }
 
 /**
  * Warning: if lowerBound and upperBound are both undefined, then everything will be deleted (unless seedId is
- * specified, which will delete everything with that seedId)
+ * specified, which will delete everything with that seedId) from the statistics table
  *
  * @param {string} seedId
  * @param {Date} lowerBound
@@ -403,18 +416,19 @@ async function deleteStatistics (lowerBound, upperBound, seedId) {
  */
 async function processAggregate (lowerBound, upperBound, seedId) {
   /**
-   * Predicates common for all seeds
+   * Predicates common for all seeds (global and time)
    *
    * @type {Predicate[]}
    */
   const commonPredicates = []
 
+  const timePredicate = getTimePredicate(lowerBound, upperBound)
+  if (timePredicate) {
+    commonPredicates.push(timePredicate)
+  }
   const globalFilterSet = await getGlobalFilterSet()
   if (globalFilterSet.filters.length) {
     commonPredicates.push(filtersToPredicate(globalFilterSet.filters))
-  }
-  if (lowerBound || upperBound) {
-    commonPredicates.push(getTimePredicate(lowerBound, upperBound))
   }
 
   const cursor = seedId
@@ -423,7 +437,7 @@ async function processAggregate (lowerBound, upperBound, seedId) {
 
   return cursor.eachAsync(async ({ id: seedId, seed: { entityRef: { id: entityId } } }) => {
     /**
-     *
+     * A selection of aggregate rows (for seed) filtered with common predicates
      * @type {Selection}
      */
     let baseSelection = commonPredicates.reduce((query, predicate) => query.filter(predicate), getAggregateBySeedId(seedId))
@@ -432,9 +446,15 @@ async function processAggregate (lowerBound, upperBound, seedId) {
 
     const intervals = intervalize(seedFilterSets)
 
+    if (intervals.length === 0) {
+      // add one interval without any filterSets
+      intervals.push({ ids: [] })
+    }
+
     for (let i = 0; i < intervals.length; i++) {
       const interval = intervals[i]
-      const intervalSelection = baseSelection.filter(r.row('startTime').during(interval.from, interval.to))
+      const intervalPredicate = getTimePredicate(interval.from, interval.to)
+      const intervalSelection = intervalPredicate === null ? baseSelection : baseSelection.filter(intervalPredicate)
 
       const seedPredicates = interval.ids.map(id => filtersToPredicate(seedFilterSets.find(sf => sf.id === id).filters))
 
@@ -468,7 +488,7 @@ function getTimePredicate (startTime, endTime) {
       ? r.row('startTime').gt(startTime)
       : endTime
         ? r.row('startTime').lt(endTime)
-        : true
+        : null
 }
 
 /**
@@ -505,15 +525,16 @@ function calculateStatistics (selection, entityId, seedId) {
       total: 1
     }))
     .reduce((left, right) =>
-      left.keys().setIntersection(right.keys()).do((intersection) =>
-        r.branch(
-          intersection.count().eq(0),
-          left.merge(right),
-          left.merge(right).merge(
-            intersection.map(language => [language, {
-              short: left.getField(language).getField('short').add(right.getField(language).getField('short')),
-              total: left.getField(language).getField('total').add(right.getField(language).getField('total'))
-            }]).coerceTo('object')))))
+      left.keys().setIntersection(right.keys())
+        .do((intersection) =>
+          r.branch(
+            intersection.count().eq(0),
+            left.merge(right),
+            left.merge(right).merge(
+              intersection.map(language => [language, {
+                short: left.getField(language).getField('short').add(right.getField(language).getField('short')),
+                total: left.getField(language).getField('total').add(right.getField(language).getField('total'))
+              }]).coerceTo('object')))))
     .ungroup()
     .map(g => {
       const executionId = g('group')
@@ -526,16 +547,16 @@ function calculateStatistics (selection, entityId, seedId) {
 }
 
 /**
- * Check if type of operation is in progress; if it is in progress throw an error, else mark type as in progress with timestamp.
+ * Check if type of operation is in progress.
+ *
+ * If it is in progress throw an error, else mark type as in progress with timestamp.
  *
  *
  * @param {string} type - type of operation
  * @returns {Promise<void>}
  */
 async function setInProgress (type) {
-  /**
-   * @type {Changes}
-   */
+  /** @type {Changes} */
   const result = await r.db(MAALFRID_DB).table(MAALFRID_TABLE_SYSTEM)
     .get('inProgress')
     .update((doc) => r.branch(
@@ -550,12 +571,13 @@ async function setInProgress (type) {
   if (result.errors > 0) {
     throw Error(result.first_error)
   }
-  if (result.changes.length < 1) {
+  if (result.unchanged) {
     throw InProgressError(type + ' already in progress')
   } else {
     const prev = result.changes[0].old_val[type] || new Date()
     const duration = Date.now() - prev.getTime()
 
+    // has current operation timed out?
     if (duration / 1000 > OPERATION_TIMEOUT) {
       await timeoutOperation(type)
     }
@@ -568,9 +590,9 @@ async function setInProgress (type) {
  * @returns {Promise<void>}
  */
 async function timeoutOperation (type) {
-  // previous operation timed out so update log entries of type without an endTime field
+  // previous operation timed out so update log entries of given type who has no endTime field
   await r.db(MAALFRID_DB).table(MAALFRID_TABLE_SYSTEM).filter({ type }).filter(r.row.hasFields('endTime').not())
-    .update({ endTime: r.now(), error: 'operation timed out or program was restarted during operation' }).run()
+    .update({ endTime: r.now(), error: 'operation timed out or program crashed during previous operation' }).run()
 }
 
 /**
@@ -592,9 +614,7 @@ async function setNotInProgress (type) {
  */
 async function logStart (type, meta) {
   const logEntry = Object.assign({ startTime: r.now(), type }, meta || {})
-  /**
-   * @type {Changes}
-   */
+  /** @type {Changes} */
   const changes = await r.db(MAALFRID_DB).table(MAALFRID_TABLE_SYSTEM).insert(logEntry).run()
   return changes.generated_keys[0]
 }
@@ -602,8 +622,8 @@ async function logStart (type, meta) {
 /**
  * Update a log entry with metadata and endTime
  *
- * @param {string} id - id of log entry
- * @param {Object} [meta] - additional data to store in the log entry
+ * @param {string} id Id of log entry
+ * @param {Object} [meta] Additional metadata to store in the log entry
  * @returns {Promise<void>}
  */
 async function logEnd (id, meta) {

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -137,14 +137,15 @@ function intervalize (filterSets) {
       return acc
     }, [])
     .sort(compareAsc)
+    .map(date => isEqual(date, minDate) || isEqual(date, maxDate) ? undefined : date)
 
   // create intervals from the intersection point
   const intervals = intersection.reduce((acc, date, index, array) => {
-    if (index > 0) {
+    if (index > 0 && date) {
       acc[acc.length - 1].to = date
     }
     if (index < array.length - 1) {
-      acc.push({ from: date, to: undefined, ids: [] })
+      acc.push(Object.assign({ ids: [] }, date ? { from: date } : {}))
     }
     return acc
   }, [])
@@ -154,7 +155,7 @@ function intervalize (filterSets) {
     .sort((a, b) => compareAsc(a.validFrom || minDate, b.validFrom || maxDate))
     .forEach((filterSet) =>
       intervals.forEach(interval => {
-        if (areRangesOverlapping(interval.from, interval.to, filterSet.validFrom || minDate, filterSet.validTo || maxDate)) {
+        if (areRangesOverlapping(interval.from || minDate, interval.to || maxDate, filterSet.validFrom || minDate, filterSet.validTo || maxDate)) {
           interval.ids.push(filterSet.id)
         }
       })

--- a/lib/typedef.js
+++ b/lib/typedef.js
@@ -39,12 +39,13 @@
  *
  * @typedef {{
  *   filter: function(*): Selection,
- *   group: function(field: string): *
+ *   group: function(field: string): *,
+ *   pluck: function(string): Selection
  * }} Selection
  *
  *
  * @typedef {{
- *   db: function(string): {table: function(string): Selection},
+ *   db: function(string): Database,
  *   branch: function(test: *, true_action: *, ...),
  *   now: function(): Date, desc: function(*): *,
  *   args: function(*): *,
@@ -59,6 +60,9 @@
  *   epochTime: function(number): Date
  * } | *} ReQL
  *
+ * @typedef {{
+ *   table: function(string): Selection,
+ * }} Database
  *
  * @typedef {{
  *   warcId: string,
@@ -104,8 +108,8 @@
  *
  * @typedef {{
  *   ids: string[],
- *   from: Date,
- *   to: Date
+ *   [from]: Date,
+ *   [to]: Date
  * }} FilterInterval
  *
  * @typedef {{

--- a/test/filter.spec.js
+++ b/test/filter.spec.js
@@ -26,7 +26,7 @@ const {
  * @type {FilterSet}}
  */
 const filterSet = require('./filter').filterSets[0]
-const intervals = require('./filter').filterSets.map(fs => {
+const filterSets = require('./filter').filterSets.map(fs => {
   if (fs.hasOwnProperty('validTo')) {
     fs.validTo = new Date(fs.validTo)
   }
@@ -339,7 +339,7 @@ describe('lib/filter.js', () => {
 
   describe('intervalize', () => {
     it('places the ids of filterSets into time intervals', () => {
-      const [a, b, c, d, e, f, g, h, i] = intervalize(intervals)
+      const [a, b, c, d, e, f, g, h, i] = intervalize(filterSets)
 
       const expected = {
         a: [a, b, c, d, e, f, g, h],
@@ -352,6 +352,14 @@ describe('lib/filter.js', () => {
       Object.entries(expected).forEach(([id, haystack]) =>
         assert.isTrue(haystack.every(needle => needle.ids.includes(id)))
       )
+    })
+
+    it('handles single interval without bounds', () => {
+      const sets = filterSets.slice(0, 1)
+      const intervals = intervalize(sets)
+      assert.equal(1, intervals.length)
+      assert.equal(1, intervals[0].ids.length)
+      assert.equal(sets[0].id, intervals[0].ids[0])
     })
   })
 })


### PR DESCRIPTION
Fixes regression which causes seeds without filters or without any filtersets to be left out of statistics. 

Also refactored to better facilitate _ad hoc_ runs.